### PR TITLE
Fix rotation comment

### DIFF
--- a/md_membrane/center_in_membrane.py
+++ b/md_membrane/center_in_membrane.py
@@ -8,7 +8,8 @@ import warnings
 # Suppress MDAnalysis PDB format warnings
 warnings.filterwarnings("ignore", category=UserWarning, module="MDAnalysis.coordinates.PDB")
 
-# We need to rotate the CNT structure 90 degrees around the z-axis to make it parallel to the membrane (as the script create cnt laid in the x-y plane)
+# We need to rotate the CNT structure 90 degrees around the x-axis to make it
+# parallel to the membrane (as the script creates the CNT lying in the x-y plane)
 
 def rotate_structure(structure, x_angle, y_angle, z_angle):
     """


### PR DESCRIPTION
## Summary
- fix inaccurate comment about the default rotation in `center_in_membrane.py`

## Testing
- `python -m py_compile md_membrane/center_in_membrane.py`

------
https://chatgpt.com/codex/tasks/task_e_6854c57a141c832a8ef4a7aa61f43e8b